### PR TITLE
adjusted syntax in line 72 to not break, since it wanted to substract…

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -69,7 +69,7 @@ logstashTest() {
   wait $test_pid
   test_status=$?
   END=$(date +%s)
-  DIFF=$(( "$END" - "$START" ))
+  DIFF=$(( $END - $START ))
   benchmarks[$TEST_DIRECTORY]="${DIFF}s"
 
   # if icdiff $TEST_RESULT_FILE "$TEST_DIRECTORY/output.log"


### PR DESCRIPTION
… strings resulting in this error:

test.sh: line 72: "1539849411" - "1539849393" : syntax error: operand expected (error token is ""1539849411" - "1539849393" ")

removing the quotes will handle the variable as integer and not as a string.