### PR TITLE
Add an option to specify a custom docker image to test with

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,13 @@ __tests__
 * Run your tests
 
 ```sh
-# ./test.sh <test-parent-directory>
+# ./test.sh <test-parent-directory> [<logstash-docker-image>]
+
+# Run tests using the official Logstash 5.5.1 docker image
 ./test.sh __tests__
+
+# Run tests using a locally built logstash docker image
+./test.sh __tests__ my_logstash_image
 ```
 
 NOTE: Multiline logs in logstash need translate in reverse to filebeat in terms of `multiline.match` from `previous` => `after` and `next` => `before`.

--- a/test.sh
+++ b/test.sh
@@ -10,6 +10,13 @@ NC='\033[0m' # No Color
 
 TEST_RESULT_FILE="test_output.log"
 TEST_PARENT_DIRECTORY=$1
+
+if [[ "$2" != "" ]]; then
+    TEST_LOGSTASH_IMAGE=$2
+else
+    TEST_LOGSTASH_IMAGE="docker.elastic.co/logstash/logstash:5.5.1"
+fi
+
 declare -A benchmarks
 
 spinner() {
@@ -55,6 +62,7 @@ logstashTest() {
   chmod 777 $TEST_RESULT_FILE
 
   START=$(date +%s)
+
   docker run \
     --rm \
     -i \
@@ -62,7 +70,7 @@ logstashTest() {
     -v "$PWD/$TEST_DIRECTORY/logstash.conf":/usr/share/logstash/pipeline/logstash.conf \
     -v "$PWD/logstash-common.conf":/usr/share/logstash/pipeline/logstash-common.conf \
     -v "$PWD/$TEST_RESULT_FILE":/output.log \
-    docker.elastic.co/logstash/logstash:5.5.1 < "$TEST_DIRECTORY/input.log" 2>/dev/null &
+    "$TEST_LOGSTASH_IMAGE" < "$TEST_DIRECTORY/input.log" 2>/dev/null &
 
   # SPINNER
   test_pid=$!


### PR DESCRIPTION
Allow specifying a specific docker image as $2 for test.sh. This
will
allow for easier testing of specific logstash versions or for custom
images with plugins that are not part of the default plugin set
installed with logstash.

Default to the original logstash version of 5.5.1.