### PR TITLE
fix check for input params

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ NC='\033[0m' # No Color
 TEST_RESULT_FILE="test_output.log"
 TEST_PARENT_DIRECTORY=$1
 
-if [[ "$2" != "" ]]; then
+if [ ! -z "${2:-}" ]; then
     TEST_LOGSTASH_IMAGE=$2
 else
     TEST_LOGSTASH_IMAGE="docker.elastic.co/logstash/logstash:5.5.1"


### PR DESCRIPTION
Fix bash strict mode throwing "unbound variable" error if only one param
provided.  Also, use common syntax for empty var check.